### PR TITLE
Orchestrate in app

### DIFF
--- a/crux-passkey-server/run.sh
+++ b/crux-passkey-server/run.sh
@@ -19,6 +19,7 @@ OPENSSL_DIR=$(pwd)/webauthn/openssl_wasm/precompiled/
 (
   cd ../web-leptos/ &&
     trunk build --release &&
+    mkdir -p ../crux-passkey-server/static/ &&
     cp dist/* ../crux-passkey-server/static/
 )
 

--- a/crux-passkey-server/webauthn/src/auth.rs
+++ b/crux-passkey-server/webauthn/src/auth.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use spin_sdk::{
     http::{IntoResponse, Params, Request, Response},
     sqlite::Connection,
+    variables,
 };
 
 use uuid::Uuid;
@@ -21,9 +22,7 @@ const LOGIN_COOKIE: &str = "crux-passkey.login";
 const REGISTER_COOKIE: &str = "crux-passkey.register";
 
 fn webauthn() -> Result<Webauthn> {
-    // let rp_id = variables::get("rp_id")?;
-    // let rp_id = "crux-passkey-server-9uqexpm2.fermyon.app";
-    let rp_id = "localhost";
+    let rp_id = variables::get("rp_id")?;
     let rp_origin = Url::parse(&format!("https://{rp_id}"))?;
     let webauthn = WebauthnBuilder::new(&rp_id, &rp_origin)?
         .rp_name("Crux Passkey")

--- a/crux-passkey-server/webauthn/src/auth.rs
+++ b/crux-passkey-server/webauthn/src/auth.rs
@@ -22,7 +22,8 @@ const REGISTER_COOKIE: &str = "crux-passkey.register";
 
 fn webauthn() -> Result<Webauthn> {
     // let rp_id = variables::get("rp_id")?;
-    let rp_id = "crux-passkey-server-9uqexpm2.fermyon.app";
+    // let rp_id = "crux-passkey-server-9uqexpm2.fermyon.app";
+    let rp_id = "localhost";
     let rp_origin = Url::parse(&format!("https://{rp_id}"))?;
     let webauthn = WebauthnBuilder::new(&rp_id, &rp_origin)?
         .rp_name("Crux Passkey")

--- a/iOS/CruxPasskey.xcodeproj/project.pbxproj
+++ b/iOS/CruxPasskey.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A307864345730D1262CE18AC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C68179492055D96C9B8A9A2A /* ContentView.swift */; };
 		C15F8E602ADBDA03F986C0C2 /* libshared_static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 164633B29E3A02F4AC7DF571 /* libshared_static.a */; };
 		CBF26363420FB2F47B4159A2 /* CruxPasskeyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E11F683B3D5B8E0A4566306 /* CruxPasskeyApp.swift */; };
+		CC199ACC2AFE2C5800660288 /* http.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC199ACB2AFE2C5800660288 /* http.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -89,6 +90,7 @@
 		6F7D93D5D403E13BF5D4378E /* CruxPasskey.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CruxPasskey.entitlements; sourceTree = "<group>"; };
 		9797B29EB4E4F9AFF0EC6E29 /* Shared */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Shared; path = ../shared/shared.xcodeproj; sourceTree = "<group>"; };
 		C68179492055D96C9B8A9A2A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		CC199ACB2AFE2C5800660288 /* http.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = http.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +162,7 @@
 				0A363D2C34B965F20D1371AC /* Data+Base64URL.swift */,
 				5507F68490A8079E3906948D /* Info.plist */,
 				466320EDA655F5A2650B075A /* passkey.swift */,
+				CC199ACB2AFE2C5800660288 /* http.swift */,
 			);
 			path = CruxPasskey;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 				CBF26363420FB2F47B4159A2 /* CruxPasskeyApp.swift in Sources */,
 				684BB9DB146B996C576F93ED /* Data+Base64URL.swift in Sources */,
 				8584282A3314421D65445E17 /* core.swift in Sources */,
+				CC199ACC2AFE2C5800660288 /* http.swift in Sources */,
 				835C8A91125FDB13D7D7773E /* passkey.swift in Sources */,
 				8F07F9D0CAB6B1EA68EE2E14 /* shared.udl in Sources */,
 			);

--- a/iOS/CruxPasskey/ContentView.swift
+++ b/iOS/CruxPasskey/ContentView.swift
@@ -4,9 +4,13 @@ import AuthenticationServices
 
 struct ContentView: View {
     @ObservedObject var core: Core
-//    @EnvironmentObject private var accountStore: AccountStore
     @State private var username: String = ""
     @FocusState private var usernameFieldIsFocused: Bool
+    
+    init(core: Core) {
+        self.core = core
+        core.update(.serverUrl("https://\(Constants.domain)"))
+    }
     
     var body: some View {
         Section {

--- a/iOS/CruxPasskey/CruxPasskeyApp.swift
+++ b/iOS/CruxPasskey/CruxPasskeyApp.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+enum Constants {
+    static let domain = "crux-passkey-server-9uqexpm2.fermyon.app"
+}
+
 @main
 struct CruxPasskeyApp: App {
   var body: some Scene {

--- a/iOS/CruxPasskey/http.swift
+++ b/iOS/CruxPasskey/http.swift
@@ -1,0 +1,30 @@
+import SharedTypes
+import SwiftUI
+
+enum HttpError: Error {
+    case generic(Error)
+    case message(String)
+}
+
+func requestHttp(_ request: HttpRequest) async -> Result<HttpResponse, HttpError> {
+    var req = URLRequest(url: URL(string: request.url)!)
+    req.httpMethod = request.method
+    req.httpBody = Data(request.body)
+
+    for header in request.headers {
+        req.addValue(header.value, forHTTPHeaderField: header.name)
+    }
+
+    do {
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let httpResponse = response as? HTTPURLResponse {
+            let status = UInt16(httpResponse.statusCode)
+            let body = [UInt8](data)
+            return .success(HttpResponse(status: status, headers: [], body: body))
+        } else {
+            return .failure(.message("bad response"))
+        }
+    } catch {
+        return .failure(.generic(error))
+    }
+}

--- a/iOS/CruxPasskey/passkey.swift
+++ b/iOS/CruxPasskey/passkey.swift
@@ -39,8 +39,6 @@ class PasskeyController:
     ASAuthorizationControllerPresentationContextProviding,
     ASAuthorizationControllerDelegate
 {
-    let domain = "crux-passkey-server-9uqexpm2.fermyon.app"
-
     var completion: ((ASAuthorizationCredential) -> Void)?
 
     fileprivate var pubKeyResponse: PublicKeyResponse
@@ -83,7 +81,7 @@ class PasskeyController:
     func signUp(with completion: @escaping (ASAuthorizationCredential) -> Void) {
         self.completion = completion
 
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: Constants.domain)
 
         let publicKey = pubKeyResponse.publicKey
         let decodedChallenge = Data(base64URLEncoded: publicKey.challenge)
@@ -100,7 +98,7 @@ class PasskeyController:
     func signIn(with completion: @escaping (ASAuthorizationCredential) -> Void) {
         self.completion = completion
 
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: Constants.domain)
 
         let publicKey = pubKeyResponse.publicKey
         let decodedChallenge = Data(base64URLEncoded: publicKey.challenge)

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,13 +12,16 @@ name = "shared"
 typegen = ["crux_core/typegen"]
 
 [dependencies]
-crux_core = "0.6"
-crux_macros = "0.3"
+crux_core = "0.6.4"
+crux_http = "0.4.2"
+crux_macros = "0.3.3"
 serde = { workspace = true, features = ["derive"] }
+serde_json = "1.0.108"
 lazy_static = "1.4.0"
 log = "0.4.20"
 uniffi = "0.25.0"
 wasm-bindgen = "0.2.88"
+webauthn-rs-proto = { version = "0.4.9", features = ["wasm"] }
 
 [target.uniffi-bindgen.dependencies]
 uniffi = { version = "0.25.0", features = ["cli"] }
@@ -28,4 +31,5 @@ uniffi = { version = "0.25.0", features = ["build"] }
 
 [dev-dependencies]
 assert_let_bind = "0.1.1"
+assert_matches = "1.5.0"
 insta = { version = "1.34.0", features = ["yaml"] }

--- a/shared/src/app.rs
+++ b/shared/src/app.rs
@@ -9,8 +9,9 @@ use webauthn_rs_proto::{
     RequestChallengeResponse,
 };
 
-// const SERVER_URL: &str = "https://crux-passkey-server-9uqexpm2.fermyon.app"; // todo: config
-const SERVER_URL: &str = "https://localhost"; // todo: config
+const SERVER_URL: &str = "https://crux-passkey-server-9uqexpm2.fermyon.app"; // todo: config
+
+// const SERVER_URL: &str = "https://localhost"; // todo: config
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Event {
@@ -22,16 +23,20 @@ pub enum Event {
     Login(String),
 
     // http...
+    #[serde(skip)]
     GetCreationChallenge(String), // register
-    GetRequestChallenge(String),  // login
+    #[serde(skip)]
+    GetRequestChallenge(String), // login
 
     #[serde(skip)]
     CreationChallenge(crux_http::Result<crux_http::Response<CreationChallengeResponse>>), // register
     #[serde(skip)]
     RequestChallenge(crux_http::Result<crux_http::Response<RequestChallengeResponse>>), // login
 
+    #[serde(skip)]
     SaveCredential(RegisterPublicKeyCredential), // register
-    VerifyCredential(PublicKeyCredential),       // login
+    #[serde(skip)]
+    VerifyCredential(PublicKeyCredential), // login
 
     #[serde(skip)]
     CredentialRegistered(crux_http::Result<crux_http::Response<Vec<u8>>>), // register
@@ -39,11 +44,15 @@ pub enum Event {
     CredentialVerified(crux_http::Result<crux_http::Response<Vec<u8>>>), // login
 
     // passkey...
+    #[serde(skip)]
     CreateCredential(CreationChallengeResponse), // register
+    #[serde(skip)]
     RequestCredential(RequestChallengeResponse), // login
 
+    #[serde(skip)]
     RegisterCredential(RegisterPublicKeyCredential), // register
-    Credential(PublicKeyCredential),                 // login
+    #[serde(skip)]
+    Credential(PublicKeyCredential), // login
 
     #[serde(skip)]
     Error(String),

--- a/shared/src/app.rs
+++ b/shared/src/app.rs
@@ -84,14 +84,15 @@ impl crux_core::App for App {
     type Capabilities = Capabilities;
 
     fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) {
-        match event.clone() {
+        info!("update: {:?}", event);
+        match event {
             Event::None => {}
             Event::Validate(user_name) => {
-                if user_name.is_empty() {
-                    model.status = Status::Error("user name cannot be empty".to_string());
+                model.status = if user_name.is_empty() {
+                    Status::Error("user name cannot be empty".to_string())
                 } else {
-                    model.status = Status::None;
-                }
+                    Status::None
+                };
                 caps.render.render();
             }
             Event::Register(user_name) => {
@@ -204,8 +205,6 @@ impl crux_core::App for App {
                 caps.render.render();
             }
         };
-
-        info!("update: {:?} {:?}", event, model);
     }
 
     fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 pub use crux_core::{bridge::Bridge, Core, Request};
+pub use crux_http as http;
 
 pub use app::*;
 pub use capabilities::passkey;

--- a/web-leptos/Cargo.toml
+++ b/web-leptos/Cargo.toml
@@ -15,6 +15,7 @@ console_log = "1.0.0"
 gloo-net = { version = "0.4.0", features = ["http"] }
 leptos = { version = "0.5.2", features = ["csr"] }
 log = "0.4.20"
+serde_json = "1.0.108"
 shared = { path = "../shared" }
 webauthn-rs-proto = { version = "0.4.9", features = ["wasm"] }
 web-sys = { version = "0.3.65", features = [

--- a/web-leptos/src/http.rs
+++ b/web-leptos/src/http.rs
@@ -1,0 +1,42 @@
+use std::str;
+
+use anyhow::Result;
+use gloo_net::http;
+
+use log::info;
+use shared::http::protocol::{HttpRequest, HttpResponse};
+use web_sys::wasm_bindgen::JsValue;
+
+pub async fn request(
+    HttpRequest {
+        method,
+        url,
+        headers,
+        body,
+    }: &HttpRequest,
+) -> Result<HttpResponse> {
+    info!("url: {}", url);
+    let mut request = match method.as_str() {
+        "GET" => http::Request::get(url),
+        "POST" => http::Request::post(url),
+        _ => panic!("not yet handling this method"),
+    };
+
+    for header in headers {
+        request = request.header(&header.name, &header.value);
+    }
+
+    let response = if body.len() > 0 {
+        request
+            .body(JsValue::from_str(str::from_utf8(body)?))
+            .expect("Failed to serialize body")
+            .send()
+            .await?
+    } else {
+        request.send().await?
+    };
+
+    let body = response.binary().await?;
+
+    Ok(HttpResponse::status(response.status()).body(body).build())
+}

--- a/web-leptos/src/main.rs
+++ b/web-leptos/src/main.rs
@@ -1,4 +1,5 @@
 mod core;
+mod http;
 mod passkey;
 
 use leptos::{

--- a/web-leptos/src/main.rs
+++ b/web-leptos/src/main.rs
@@ -4,7 +4,7 @@ mod passkey;
 
 use leptos::{
     component, create_effect, create_node_ref, create_signal, ev::SubmitEvent, event_target_value,
-    html::Input, view, IntoView, NodeRef, SignalGet, SignalUpdate,
+    html::Input, view, window, IntoView, NodeRef, SignalGet, SignalUpdate,
 };
 use shared::Event;
 
@@ -12,7 +12,9 @@ use shared::Event;
 fn RootComponent() -> impl IntoView {
     let core = core::new();
     let (view, render) = create_signal(core.view());
-    let (event, set_event) = create_signal(Event::None);
+    let (event, set_event) = create_signal(Event::ServerUrl(
+        window().location().origin().expect("origin to exist"),
+    ));
 
     create_effect(move |_| {
         core::update(&core, event.get(), render);

--- a/web-leptos/src/passkey.rs
+++ b/web-leptos/src/passkey.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use gloo_net::http;
 use leptos::*;
 use log::info;
 use shared::passkey::{PasskeyOperation, PasskeyOutput};
@@ -12,101 +11,53 @@ use webauthn_rs_proto::{
 
 pub async fn request(operation: &PasskeyOperation) -> Result<PasskeyOutput> {
     match operation {
-        PasskeyOperation::Register(user_name) => {
-            info!("Registering user: {}", user_name);
-            register(&user_name).await?;
-            Ok(PasskeyOutput::Registered)
-        }
-        PasskeyOperation::Login(user_name) => {
-            info!("Logging in user: {}", user_name);
-            login(&user_name).await?;
-            Ok(PasskeyOutput::LoggedIn)
-        }
-    }
-}
+        PasskeyOperation::CreateCredential(bytes) => {
+            let ccr = serde_json::from_slice::<CreationChallengeResponse>(bytes)?;
+            // First, convert from our webauthn proto json safe format, into the browser
+            // compatible struct, with everything decoded as needed.
+            let c_options: web_sys::CredentialCreationOptions = ccr.into();
+            info!("c_options: {:?}", c_options);
 
-async fn register(user_name: &str) -> Result<()> {
-    let start_url = &format!("/auth/register_start/{}", user_name);
-    let finish_url = "/auth/register_finish";
-    let response = http::Request::get(start_url).send().await?;
-    if response.ok() {
-        let ccr = response.json::<CreationChallengeResponse>().await?;
+            // Create a promise that calls the browsers navigator.credentials.create api.
+            let promise = window()
+                .navigator()
+                .credentials()
+                .create_with_options(&c_options)
+                .expect_throw("Unable to create promise");
+            match JsFuture::from(promise).await {
+                Ok(js_val) => {
+                    let cred = web_sys::PublicKeyCredential::from(js_val);
+                    let cred = RegisterPublicKeyCredential::from(cred);
 
-        // First, convert from our webauthn proto json safe format, into the browser
-        // compatible struct, with everything decoded as needed.
-        let c_options: web_sys::CredentialCreationOptions = ccr.into();
-        info!("c_options: {:?}", c_options);
-
-        // Create a promise that calls the browsers navigator.credentials.create api.
-        let promise = window()
-            .navigator()
-            .credentials()
-            .create_with_options(&c_options)
-            .expect_throw("Unable to create promise");
-        match JsFuture::from(promise).await {
-            Ok(js_val) => {
-                let cred = web_sys::PublicKeyCredential::from(js_val);
-
-                let cred = RegisterPublicKeyCredential::from(cred);
-
-                let response = http::Request::post(finish_url)
-                    .json(&cred)
-                    .expect("Failed to serialize cred")
-                    .send()
-                    .await?;
-                if response.ok() {
-                    info!("Registered user: {}", user_name);
-                    Ok(())
-                } else {
-                    Err(anyhow!("Failed to register: {}", response.status()))
+                    Ok(PasskeyOutput::RegisterCredential(serde_json::to_vec(
+                        &cred,
+                    )?))
                 }
+                e @ Err(_) => Err(anyhow!("Failed to register: {:?}", e)),
             }
-            e @ Err(_) => Err(anyhow!("Failed to register: {:?}", e)),
         }
-    } else {
-        Err(anyhow!("Failed to register: {}", response.status()))
-    }
-}
+        PasskeyOperation::RequestCredential(bytes) => {
+            let ccr = serde_json::from_slice::<RequestChallengeResponse>(bytes)?;
+            // First, convert from our webauthn proto json safe format, into the browser
+            // compatible struct, with everything decoded as needed.
+            let c_options: web_sys::CredentialRequestOptions = ccr.into();
+            info!("c_options: {:?}", c_options);
 
-async fn login(user_name: &str) -> Result<()> {
-    let start_url = &format!("/auth/login_start/{}", user_name);
-    let finish_url = "/auth/login_finish";
-    let response = http::Request::get(start_url).send().await?;
-    if response.ok() {
-        let ccr = response.json::<RequestChallengeResponse>().await?;
+            // Create a promise that calls the browsers navigator.credentials.create api.
+            let promise = window()
+                .navigator()
+                .credentials()
+                .get_with_options(&c_options)
+                .expect_throw("Unable to create promise");
+            match JsFuture::from(promise).await {
+                Ok(js_val) => {
+                    let cred = web_sys::PublicKeyCredential::from(js_val);
+                    let cred = PublicKeyCredential::from(cred);
 
-        // First, convert from our webauthn proto json safe format, into the browser
-        // compatible struct, with everything decoded as needed.
-        let c_options: web_sys::CredentialRequestOptions = ccr.into();
-        info!("c_options: {:?}", c_options);
-
-        // Create a promise that calls the browsers navigator.credentials.create api.
-        let promise = window()
-            .navigator()
-            .credentials()
-            .get_with_options(&c_options)
-            .expect_throw("Unable to create promise");
-        match JsFuture::from(promise).await {
-            Ok(js_val) => {
-                let cred = web_sys::PublicKeyCredential::from(js_val);
-
-                let cred = PublicKeyCredential::from(cred);
-
-                let response = http::Request::post(finish_url)
-                    .json(&cred)
-                    .expect("Failed to serialize cred")
-                    .send()
-                    .await?;
-                if response.ok() {
-                    info!("Logged in user: {}", user_name);
-                    Ok(())
-                } else {
-                    Err(anyhow!("Failed to authenticate: {}", response.status()))
+                    Ok(PasskeyOutput::Credential(serde_json::to_vec(&cred)?))
                 }
+                e @ Err(_) => Err(anyhow!("Failed to authenticate: {:?}", e)),
             }
-            e @ Err(_) => Err(anyhow!("Failed to authenticate: {:?}", e)),
         }
-    } else {
-        Err(anyhow!("Failed to authenticate: {}", response.status()))
     }
 }


### PR DESCRIPTION
This PR moves the orchestration logic from the shell-side capability to the app.

- [x] move orchestration to app, adding the http capability, and thinning out the passkey capability
- [ ] finish the tests
- [x] do the same for iOS
- [ ] make it all into a nested sub-app for reuse